### PR TITLE
Fix component pipeline tests

### DIFF
--- a/components/__init__.py
+++ b/components/__init__.py
@@ -22,5 +22,8 @@ from components.component_utils import (
     COMPONENT_FIELDS
 )
 
+# Expose main pipeline helper so tests can import directly from the package
+from components.direct_component_analyzer import assign_components_and_relationships
+
 # Version information
 __version__ = '1.0.0'

--- a/components/component_utils.py
+++ b/components/component_utils.py
@@ -49,8 +49,8 @@ def apply_component_fields(data: Dict, component_fields: Dict) -> Dict:
     """
     # Properly handle the case where data is None or not a dictionary
     if data is None:
-        data = {}
-    elif not isinstance(data, dict):
+        return None
+    if not isinstance(data, dict):
         return data
         
     # Handle the case where component_fields is None or empty

--- a/components/direct_component_analyzer.py
+++ b/components/direct_component_analyzer.py
@@ -352,12 +352,15 @@ class ComponentAnalyzer:
         if logging.getLogger().isEnabledFor(logging.DEBUG) and errors:
             error_before = copy.deepcopy(errors[0])
         
-        # Add root cause info to first error (for Excel output)
-        errors[0]['root_cause_component'] = self._primary_issue_component
-        
-        # Get component from registry
+        # Add root cause info to first error without overriding existing values
+        first_error = errors[0]
+        if 'root_cause_component' not in first_error:
+            first_error['root_cause_component'] = self._primary_issue_component
+
+        # Get component from registry for description
         component = self.registry.get_component(self._primary_issue_component)
-        errors[0]['root_cause_description'] = component.description
+        if 'root_cause_description' not in first_error:
+            first_error['root_cause_description'] = component.description
         
         # Use related_to from registry if available
         related_components = []


### PR DESCRIPTION
## Summary
- expose `assign_components_and_relationships` via package init
- preserve root cause fields in `direct_component_analyzer`
- handle `None` correctly in `apply_component_fields`
- ensure tests use mock pipeline helpers

## Testing
- `python tests/legacy_test_runner.py`