### PR TITLE
Add HTML reference validation to reports

### DIFF
--- a/reports/component_report.py
+++ b/reports/component_report.py
@@ -70,7 +70,7 @@ def generate_component_report(
         Path to the generated HTML report
     """
     # Verify directory structure before generating report
-    from utils.path_validator import fix_directory_structure
+from utils.path_validator import fix_directory_structure, check_html_references
     fix_directory_structure(output_dir, test_id)
     
     # Sanitize output directory to prevent nesting
@@ -587,9 +587,21 @@ def generate_component_report(
     with open(report_path, 'w', encoding='utf-8') as f:
         f.write(html)
     
+    # Validate HTML references
+    try:
+        html_issues = check_html_references(report_path)
+        total_issues = sum(len(v) for v in html_issues.values())
+        if total_issues > 0:
+            logging.warning(f"HTML reference issues found in {report_path}:")
+            for issue_type, issues in html_issues.items():
+                for issue in issues:
+                    logging.warning(f"  {issue_type}: {issue}")
+    except Exception as e:
+        logging.error(f"Failed to validate HTML references: {e}")
+
     # Log what we've done
     logging.info(f"Generated component report at {report_path}")
-    
+
     return report_path
 
 

--- a/step_aware_analyzer.py
+++ b/step_aware_analyzer.py
@@ -9,6 +9,7 @@ from gherkin_log_correlator import GherkinParser, LogEntry, correlate_logs_with_
 
 # Import timeline generators directly from reports.visualizations
 from reports.visualizations import generate_timeline_image, generate_cluster_timeline_image, generate_visualization_placeholder
+from utils.path_validator import check_html_references
 
 # Import Config for feature flags - if it exists
 try:
@@ -656,6 +657,17 @@ def generate_step_report(
         with open(report_path, 'w', encoding='utf-8') as f:
             f.write(html)
         
+        try:
+            html_issues = check_html_references(report_path)
+            total_issues = sum(len(v) for v in html_issues.values())
+            if total_issues > 0:
+                logging.warning(f"HTML reference issues detected in step report {report_path}:")
+                for issue_type, issues in html_issues.items():
+                    for issue in issues:
+                        logging.warning(f"  {issue_type}: {issue}")
+        except Exception as e:
+            logging.error(f"Failed to validate HTML references: {e}")
+
         logging.info(f"Generated step-aware HTML report with {timeline_type} timeline image: {report_path}")
         return report_path
     


### PR DESCRIPTION
## Summary
- validate HTML references for component reports
- run same validation for step aware reports

## Testing
- `pytest -q` *(fails: command not found)*
- `flake8` *(fails: command not found)*