### PR TITLE
Fix indentation in component_report

### DIFF
--- a/reports/component_report.py
+++ b/reports/component_report.py
@@ -78,7 +78,7 @@ def generate_component_report(
         Path to the generated HTML report
     """
     # Verify directory structure before generating report
-from utils.path_validator import fix_directory_structure, check_html_references
+    from utils.path_validator import fix_directory_structure, check_html_references
     fix_directory_structure(output_dir, test_id)
     
     # Sanitize output directory to prevent nesting


### PR DESCRIPTION
## Summary
- fix indentation error in component_report

## Testing
- `python -m py_compile reports/component_report.py`
- `pytest -q` *(fails: command not found)*