### PR TITLE
Fix SyntaxErrors in step_aware_analyzer

### DIFF
--- a/step_aware_analyzer.py
+++ b/step_aware_analyzer.py
@@ -41,6 +41,7 @@ def extract_step_name(step_number, feature_file):
             if step.step_number == step_number:
                 return f"{step.keyword} {step.text}"
         return f"Step {step_number} (Unknown)"
+    except Exception as e:
         logging.error(f"Error extracting step name: {str(e)}")
         return f"Step {step_number} (Unknown)"
 
@@ -71,9 +72,9 @@ def validate_timestamp(timestamp):
                     return datetime.strptime(timestamp, fmt)
                 except ValueError:
                     continue
-                    
         logging.warning(f"Unable to parse timestamp: {timestamp}")
         return None
+    except Exception as e:
         logging.error(f"Error validating timestamp {timestamp}: {str(e)}")
         return None
 
@@ -248,6 +249,7 @@ def generate_step_report(
     # Ensure output directory exists
     try:
         os.makedirs(output_dir, exist_ok=True)
+    except Exception as e:
         error_msg = f"Failed to create output directory {output_dir}: {str(e)}"
         logging.error(error_msg)
         raise OSError(error_msg) from e
@@ -332,7 +334,7 @@ def generate_step_report(
                     timeline_image_path = None
             else:
                 logging.warning("Failed to generate timeline image - path is None")
-                
+        except Exception as e:
             logging.error(f"Error generating timeline image: {str(e)}")
             traceback.print_exc()
             # Continue without timeline
@@ -347,9 +349,10 @@ def generate_step_report(
             timeline_image_path = generate_visualization_placeholder(
                 output_dir,
                 test_id,
-                "Timeline visualization failed: insufficient step data"
+                "Timeline visualization failed: insufficient step data",
             )
             logging.info(f"Generated placeholder image: {timeline_image_path}")
+        except Exception as e:
             logging.error(f"Error generating placeholder: {str(e)}")
             traceback.print_exc()
     
@@ -370,7 +373,6 @@ def generate_step_report(
         image_relative_path = image_relative_path.replace(os.sep, "/")
     
     # Check for component analysis report
-codex/add-jinja2-templates-and-update-reports
     component_report_file = f"{test_id}_component_report.html"
     component_report_path = os.path.join(output_dir, component_report_file)
     component_report_available = os.path.exists(component_report_path)
@@ -473,7 +475,6 @@ codex/add-jinja2-templates-and-update-reports
         except Exception:
             return report_path
 
-=======
     component_report_file = f"{test_id}_component_report.html"
     component_report_path = os.path.join(output_dir, component_report_file)
     component_report_available = os.path.exists(component_report_path)
@@ -803,7 +804,6 @@ codex/add-jinja2-templates-and-update-reports
         except:
             # If we can't even write the error report, just return the path that would have been
             return report_path
- main
 
 def run_step_aware_analysis(
     test_id: str, 
@@ -845,6 +845,7 @@ def run_step_aware_analysis(
     # Ensure output directory exists
     try:
         os.makedirs(output_dir, exist_ok=True)
+    except Exception as e:
         logging.error(f"Failed to create output directory {output_dir}: {str(e)}")
         return None
     
@@ -861,6 +862,7 @@ def run_step_aware_analysis(
             return None
             
         logging.info(f"Found {len(log_files)} log files for analysis")
+    except Exception as e:
         logging.error(f"Error finding log files: {str(e)}")
         return None
     
@@ -892,6 +894,7 @@ def run_step_aware_analysis(
                 from gpt_summarizer import enrich_logs_with_errors
                 step_to_logs = enrich_logs_with_errors(step_to_logs, errors)
                 logging.info("Enhanced log entries with error information")
+            except Exception as e:
                 logging.warning(f"Error enriching logs with error info: {str(e)}")
         
         # Generate HTML report
@@ -906,6 +909,7 @@ def run_step_aware_analysis(
         )
         
         return report_path
+    except Exception as e:
         logging.error(f"Error in step-aware analysis: {str(e)}")
         traceback.print_exc()
         return None


### PR DESCRIPTION
## Summary
- add missing exception handlers in `step_aware_analyzer.py`
- clean leftover merge artifacts and stray lines

## Testing
- `python -m py_compile step_aware_analyzer.py`
- `python controller.py` *(fails: ModuleNotFoundError: No module named 'sklearn')*