### PR TITLE
Fix nested json paths

### DIFF
--- a/components/component_integration.py
+++ b/components/component_integration.py
@@ -155,7 +155,8 @@ class ComponentIntegration:
             log_entries = self.analyzer.enrich_log_entries_with_components(log_entries)
             errors = self.analyzer.enrich_log_entries_with_components(errors)
             
-            # Set the JSON directory
+            # Sanitize output directory and ensure json path exists
+            output_dir = sanitize_base_directory(output_dir, "json")
             json_dir = os.path.join(output_dir, "json")
             os.makedirs(json_dir, exist_ok=True)
             
@@ -259,7 +260,7 @@ class ComponentIntegration:
             results["causality_paths"] = causality_paths
             
             # Export error graph
-            error_graph_path = self.clusterer.export_error_graph(json_dir, test_id)
+            error_graph_path = self.clusterer.export_error_graph(output_dir, test_id)
             if error_graph_path:
                 results["analysis_files"]["error_graph"] = error_graph_path
             

--- a/components/context_aware_clusterer.py
+++ b/components/context_aware_clusterer.py
@@ -702,12 +702,12 @@ class ContextAwareClusterer:
         # Sort by weight and return top 10 paths
         return [p[0] for p in sorted(weighted_paths, key=lambda x: x[1], reverse=True)[:10]]
     
-    def export_error_graph(self, output_path: str, test_id: str = "Unknown") -> str:
+    def export_error_graph(self, output_dir: str, test_id: str = "Unknown") -> str:
         """
         Export error graph as a JSON file for visualization.
         
         Args:
-            output_path: Directory to save the JSON file
+            output_dir: Base directory to save the JSON file
             test_id: Test ID for filename
             
         Returns:
@@ -715,9 +715,14 @@ class ContextAwareClusterer:
         """
         if not self.error_graph:
             return None
-            
-        os.makedirs(output_path, exist_ok=True)
-        json_path = os.path.join(output_path, f"{test_id}_error_graph.json")
+
+        sanitized_dir = sanitize_base_directory(output_dir, "json")
+        json_path = get_output_path(
+            sanitized_dir,
+            test_id,
+            get_standardized_filename(test_id, "error_graph", "json"),
+            OutputType.JSON_DATA,
+        )
         
         # Convert graph to dictionary
         graph_dict = {

--- a/reports/report_manager.py
+++ b/reports/report_manager.py
@@ -584,9 +584,17 @@ class ReportManager:
                     if "analysis_files" not in component_analysis:
                         component_analysis["analysis_files"] = {}
                     
+                    sanitized_base = sanitize_base_directory(self.base_dir, "json")
                     for viz_type, viz_path in visualization_paths.items():
                         if viz_path and os.path.exists(viz_path):
-                            component_analysis["analysis_files"][viz_type] = viz_path
+                            sanitized_path = get_output_path(
+                                sanitized_base,
+                                self.config.test_id,
+                                os.path.basename(viz_path),
+                                OutputType.JSON_DATA,
+                                create_dirs=False,
+                            )
+                            component_analysis["analysis_files"][viz_type] = sanitized_path
             
             # Create report data object with processed data
             report_data = ReportData(


### PR DESCRIPTION
## Summary
- sanitize the analysis_file paths generated in ReportManager
- avoid creating a nested json directory when analyzing logs
- standardize error graph export path

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*