### PR TITLE
Add HTML report feature flags

### DIFF
--- a/docs/orbit-readme.md
+++ b/docs/orbit-readme.md
@@ -265,6 +265,8 @@ ENABLE_COMPONENT_DISTRIBUTION = True
 ENABLE_ERROR_PROPAGATION = True
 ENABLE_STEP_REPORT_IMAGES = True
 ENABLE_COMPONENT_REPORT_IMAGES = True
+ENABLE_STEP_REPORT = True        # Generate step-aware HTML report
+ENABLE_COMPONENT_HTML = True    # Generate component analysis HTML report
 ```
 
 ---

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -3,6 +3,7 @@ reports/__init__.py - Package initialization and main entry point for report gen
 """
 
 import sys
+import os
 import logging
 import copy
 from datetime import datetime
@@ -55,7 +56,9 @@ def write_reports(
     component_analysis: dict = None,
     primary_issue_component: str = "unknown",
     component_report_path: str = None,
-    component_diagnostic: dict = None
+    component_diagnostic: dict = None,
+    enable_step_report: Optional[bool] = None,
+    enable_component_html: Optional[bool] = None
 ) -> dict:
     """
     Write comprehensive reports with enhanced component information preservation.
@@ -96,6 +99,15 @@ def write_reports(
     logging.info(f"Component distribution (sample): {component_distribution}")
     logging.info(f"Primary issue component: {primary_issue_component}")
     
+    # Determine optional feature flags
+    if enable_step_report is None:
+        env_flag = os.getenv("ENABLE_STEP_REPORT")
+        enable_step_report = str(env_flag).lower() in ("true", "1", "yes") if env_flag is not None else True
+
+    if enable_component_html is None:
+        env_flag = os.getenv("ENABLE_COMPONENT_HTML")
+        enable_component_html = str(env_flag).lower() in ("true", "1", "yes") if env_flag is not None else True
+
     # Create config
     config = ReportConfig(
         output_dir=output_dir,
@@ -105,7 +117,9 @@ def write_reports(
         enable_markdown=True,
         enable_json=True,
         enable_docx=True,
-        enable_component_report=True
+        enable_component_report=True,
+        enable_step_report=enable_step_report,
+        enable_component_html=enable_component_html
     )
     
     # Create data container

--- a/reports/base.py
+++ b/reports/base.py
@@ -566,7 +566,9 @@ class ReportConfig:
                 enable_markdown: bool = True,
                 enable_json: bool = True,
                 enable_docx: bool = True,
-                enable_component_report: bool = True):
+                enable_component_report: bool = True,
+                enable_step_report: bool = True,
+                enable_component_html: bool = True):
         """
         Initialize report configuration.
         
@@ -578,7 +580,9 @@ class ReportConfig:
             enable_markdown: Whether to generate Markdown reports
             enable_json: Whether to generate JSON reports
             enable_docx: Whether to generate DOCX reports
-            enable_component_report: Whether to generate component reports
+            enable_component_report: Whether to generate component visualizations
+            enable_step_report: Whether to generate the step-aware HTML report
+            enable_component_html: Whether to generate the component analysis HTML report
         """
         self.output_dir = output_dir
         self.test_id = test_id
@@ -589,6 +593,8 @@ class ReportConfig:
         self.enable_json = enable_json
         self.enable_docx = enable_docx
         self.enable_component_report = enable_component_report
+        self.enable_step_report = enable_step_report
+        self.enable_component_html = enable_component_html
         
         # Create output directory if it doesn't exist
         os.makedirs(output_dir, exist_ok=True)

--- a/reports/report_manager.py
+++ b/reports/report_manager.py
@@ -521,7 +521,7 @@ class ReportManager:
             self._verify_component_consistency(normalized_errors, self.config.primary_issue_component)
             
             # STEP 9: Generate component report (using path utilities)
-            if self.config.enable_component_report:
+            if self.config.enable_component_report and self.config.enable_component_html:
                 component_report_filename = get_standardized_filename(self.config.test_id, "component_report", "html")
                 component_report_path = get_output_path(
                     self.base_dir,

--- a/step_aware_analyzer.py
+++ b/step_aware_analyzer.py
@@ -807,13 +807,14 @@ def generate_step_report(
             return report_path
 
 def run_step_aware_analysis(
-    test_id: str, 
-    feature_file: str, 
-    logs_dir: str, 
+    test_id: str,
+    feature_file: str,
+    logs_dir: str,
     output_dir: str,
     clusters: Optional[Dict[int, List[Dict]]] = None,
     errors: Optional[List[Dict]] = None,
-    component_analysis: Optional[Dict[str, Any]] = None
+    component_analysis: Optional[Dict[str, Any]] = None,
+    enable_step_report: Optional[bool] = None
 ) -> Optional[str]:
     """
     Run a step-aware analysis and generate HTML report.
@@ -830,6 +831,11 @@ def run_step_aware_analysis(
     Returns:
         Path to the generated report or None if analysis failed
     """
+    # Determine if report generation is enabled
+    if enable_step_report is None:
+        env_flag = os.getenv("ENABLE_STEP_REPORT")
+        enable_step_report = str(env_flag).lower() in ("true", "1", "yes") if env_flag is not None else True
+
     # Input validation
     if not test_id:
         logging.error("No test ID provided")
@@ -898,17 +904,18 @@ def run_step_aware_analysis(
             except Exception as e:
                 logging.warning(f"Error enriching logs with error info: {str(e)}")
         
-        # Generate HTML report
-        report_path = generate_step_report(
-            feature_file=feature_file,
-            logs_dir=logs_dir,
-            step_to_logs=step_to_logs,
-            output_dir=output_dir,
-            test_id=test_id,
-            clusters=clusters,
-            component_analysis=component_analysis
-        )
-        
+        report_path = None
+        if enable_step_report:
+            report_path = generate_step_report(
+                feature_file=feature_file,
+                logs_dir=logs_dir,
+                step_to_logs=step_to_logs,
+                output_dir=output_dir,
+                test_id=test_id,
+                clusters=clusters,
+                component_analysis=component_analysis
+            )
+
         return report_path
     except Exception as e:
         logging.error(f"Error in step-aware analysis: {str(e)}")


### PR DESCRIPTION
## Summary
- extend `ReportConfig` with `enable_step_report` and `enable_component_html`
- expose these flags in `write_reports`
- respect flags when running Gherkin correlation and component report generation
- skip HTML generation in `ReportManager` when disabled
- update step-aware analyzer to honour `ENABLE_STEP_REPORT`
- document the new environment variables

## Testing
- `pytest -q` *(fails: command not found)*