### PR TITLE
Remove placeholder timeline fallback

### DIFF
--- a/reports/templates/step_report.html.j2
+++ b/reports/templates/step_report.html.j2
@@ -25,8 +25,8 @@
 </div>
 {% else %}
 <div id="timeline-section" class="error-message">
-    <p><strong>Timeline Image Unavailable</strong></p>
-    <p>No timeline image could be generated for this report.</p>
+    <p><strong>Timeline could not be generated</strong></p>
+    <p>The timeline visualization was not created due to missing data or an error.</p>
 </div>
 {% endif %}
 {% if component_analysis %}

--- a/reports/visualizations.py
+++ b/reports/visualizations.py
@@ -541,17 +541,32 @@ def generate_cluster_timeline_image(step_to_logs, step_dict, clusters, output_di
     
     # Acquire lock to prevent concurrent generation of the same visualization
     with _visualization_locks["cluster_timeline"]:
+        # Configure matplotlib
+        configure_matplotlib()
+
+        # Get path for visualization
+        image_path = get_viz_path(output_dir, test_id, "cluster_timeline")
+
         # Validate input data
         if not step_to_logs or not step_dict or not clusters:
             logging.warning("Missing required data for cluster timeline visualization")
-            return handle_empty_data(output_dir, test_id, "cluster_timeline", 
-                                   "Insufficient data for cluster timeline visualization")
-    
-        # Configure matplotlib
-        configure_matplotlib()
-        
-        # Get path for visualization
-        image_path = get_viz_path(output_dir, test_id, "cluster_timeline")
+            try:
+                fig = plt.figure(figsize=(8, 6))
+                plt.text(
+                    0.5,
+                    0.5,
+                    "Insufficient data for cluster timeline visualization",
+                    ha="center",
+                    va="center",
+                    fontsize=12,
+                    wrap=True,
+                )
+                plt.axis("off")
+                image_path = save_figure(fig, image_path)
+                return image_path
+            except Exception as e:
+                logging.error(f"Error creating fallback cluster timeline: {str(e)}")
+                return None
         
         # Get path for debug log
         if HAS_PATH_UTILS:

--- a/step_aware_analyzer.py
+++ b/step_aware_analyzer.py
@@ -9,7 +9,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from gherkin_log_correlator import GherkinParser, LogEntry, correlate_logs_with_steps
 
 # Import timeline generators directly from reports.visualizations
-from reports.visualizations import generate_timeline_image, generate_cluster_timeline_image, generate_visualization_placeholder
+from reports.visualizations import generate_timeline_image, generate_cluster_timeline_image
 from utils.path_validator import check_html_references
 
 # Import Config for feature flags - if it exists
@@ -344,18 +344,10 @@ def generate_step_report(
         if not enable_images:
             logging.info("Timeline images are disabled via configuration")
     
-    # IMPLEMENTATION CHANGE (Module 2): Add fallback if timeline generation failed
+
+    # If timeline generation failed entirely, leave the image path empty.
     if not timeline_image_path:
-        try:
-            timeline_image_path = generate_visualization_placeholder(
-                output_dir,
-                test_id,
-                "Timeline visualization failed: insufficient step data",
-            )
-            logging.info(f"Generated placeholder image: {timeline_image_path}")
-        except Exception as e:
-            logging.error(f"Error generating placeholder: {str(e)}")
-            traceback.print_exc()
+        logging.warning("Timeline could not be generated")
     
     # Get relative path to the image for HTML embedding
     # Use consistent supporting_images/ prefix for HTML references

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -1090,9 +1090,11 @@ class TestStepAwareAnalyzer(unittest.TestCase):
         # Explicitly specify UTF-8 encoding to avoid decoding errors
         with open(report_path, "r", encoding="utf-8") as f:
             html_content = f.read()
-            
+
         # Verify that image path uses supporting_images prefix
         self.assertIn('src="supporting_images/timeline.png"', html_content)
+        # Ensure a real timeline image was referenced
+        self.assertNotIn('visualization_placeholder', html_content)
         
         # Verify that step logs are included
         self.assertIn("Step 1", html_content)
@@ -1150,9 +1152,11 @@ class TestStepAwareAnalyzer(unittest.TestCase):
             # Explicitly specify UTF-8 encoding to avoid decoding errors
             with open(report_path, "r", encoding="utf-8") as f:
                 html_content = f.read()
-                
+
             # Verify that image path uses supporting_images prefix
             self.assertIn('src="supporting_images/cluster_timeline.png"', html_content)
+            # Ensure no placeholder image is referenced
+            self.assertNotIn('visualization_placeholder', html_content)
             
             # Verify that component analysis is included
             self.assertIn("Root Cause Component", html_content)
@@ -1279,8 +1283,9 @@ class TestStepAwareAnalyzer(unittest.TestCase):
         with open(report_path, "r", encoding="utf-8") as f:
             html_content = f.read()
             
-        # Verify error message is included
-        self.assertIn("Timeline Visualization Unavailable", html_content)
+        # Verify error notice is included and no placeholder image is referenced
+        self.assertIn("Timeline could not be generated", html_content)
+        self.assertNotIn('visualization_placeholder', html_content)
 
 
 @TestRegistry.register(category='integration', importance=2)


### PR DESCRIPTION
## Summary
- remove placeholder generation from `generate_step_report`
- use warning message when a timeline cannot be produced
- display new message in step report template
- produce simple fallback image in `generate_cluster_timeline_image`
- update integration tests for new behaviour

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*