### PR TITLE
Improve step-aware analysis docs

### DIFF
--- a/docs/Orbit_Getting_Started.md
+++ b/docs/Orbit_Getting_Started.md
@@ -105,6 +105,8 @@ DEFAULT_MODEL=gpt-3.5-turbo
 LOG_BASE_DIR=path/to/logs
 OUTPUT_BASE_DIR=path/to/output
 ENABLE_OCR=True
+ENABLE_STEP_REPORT=True
+ENABLE_STEP_REPORT_IMAGES=True
 ```
 
 > If you don't set an API key, Orbit will run in **offline mode** (no AI summary, but everything else still works).
@@ -146,6 +148,13 @@ Or analyze all tests in your logs directory:
 orbit_analyzer.exe --batch --all
 ```
 
+### Step-Aware Analysis (Optional)
+
+1. Include the matching `.feature` file in your `logs\SXM-xxxxxxx` folder.
+2. By default a step report will be created showing each log entry by Gherkin step.
+3. Set `ENABLE_STEP_REPORT=false` to disable the report, or `ENABLE_STEP_REPORT_IMAGES=false` to skip timeline images.
+4. Open `output\SXM-xxxxxxx\SXM-xxxxxxx_step_report.html` to view the results.
+
 ---
 
 ## 📊 Output Location
@@ -158,6 +167,7 @@ output/
     ├── SXM-2302295_log_analysis.xlsx       # Main Excel report
     ├── SXM-2302295_bug_report.docx         # Bug report document
     ├── SXM-2302295_log_analysis.md         # Markdown report
+    ├── SXM-2302295_step_report.html        # Full step report
     ├── SXM-2302295_component_report.html   # Component analysis report
     │
     ├── json/                               # Detailed data files

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -100,12 +100,23 @@ python batch_processor.py --all
 python batch_processor.py --all --parallel
 ```
 
+### Step-Aware Analysis
+
+To generate a detailed step report:
+
+1. Place the corresponding `.feature` file in your log folder (`logs\SXM-xxxxxxx`).
+2. The analyzer will correlate each log entry with the matching Gherkin step.
+3. Set `ENABLE_STEP_REPORT=false` to skip creating the report.
+4. Set `ENABLE_STEP_REPORT_IMAGES=false` to omit timeline images.
+
+The resulting file is saved as `output\SXM-xxxxxxx\SXM-xxxxxxx_step_report.html`.
+
 ### Output Reports
 
 All reports are generated in the `output\SXM-xxxxxxx` folder:
 - `log_analysis.html` - Main HTML report
 - `SXM-xxxxxxx_bug_report.docx` - Ready-to-submit bug report
-- `SXM-xxxxxxx_step_report.html` - Step-aware analysis (if feature file found)
+- `SXM-xxxxxxx_step_report.html` - Full step report located in `output\SXM-xxxxxxx`
 - `SXM-xxxxxxx_component_report.html` - Component relationship analysis
 - Various visualization files (PNG)
 
@@ -196,6 +207,8 @@ Configure by editing `config.py` or setting environment variables:
 * `OPENAI_API_KEY`: API key for GPT analysis (set as environment variable)
 * `DEFAULT_MODEL`: GPT model to use (default: `gpt-3.5-turbo`)
 * `ENABLE_OCR`: Whether to extract text from images (default: `True`)
+* `ENABLE_STEP_REPORT`: Generate the step-aware HTML report (default: `True`)
+* `ENABLE_STEP_REPORT_IMAGES`: Include timeline images in the step report (default: `True`)
 
 For secure API key storage, you can use the Windows Credential Manager:
 


### PR DESCRIPTION
## Summary
- document how to enable step-aware reports
- mention ENABLE_STEP_REPORT and ENABLE_STEP_REPORT_IMAGES flags
- show where to find the `{test_id}_step_report.html` file

## Testing
- `pytest -q` *(fails: command not found)*
- `pre-commit run --files docs/readme.md docs/Orbit_Getting_Started.md` *(fails: command not found)*
- `python -m py_compile config.py`