### PR TITLE
Standardize logging setup

### DIFF
--- a/component_diagnostic.py
+++ b/component_diagnostic.py
@@ -1,20 +1,13 @@
 # component_diagnostic.py
 import os
 import logging
+from config import Config
 import json
 import re
 from collections import defaultdict
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    filename='component_diagnostic.log',
-    filemode='w'
-)
-console = logging.StreamHandler()
-console.setLevel(logging.INFO)
-logging.getLogger('').addHandler(console)
+Config.setup_logging()
 
 # Enhanced component model
 COMPONENT_MODEL = {

--- a/gherkin_log_correlator.py
+++ b/gherkin_log_correlator.py
@@ -602,7 +602,7 @@ if __name__ == "__main__":
     feature_file = sys.argv[1]
     log_files = sys.argv[2:]
     
-    logging.basicConfig(level=logging.INFO)
+    Config.setup_logging()
     results = correlate_logs_with_steps(feature_file, log_files)
     
     # Print summary

--- a/gpt_summarizer.py
+++ b/gpt_summarizer.py
@@ -1290,7 +1290,7 @@ def test_token_management(test_id="SXM-3690790"):
     """
     try:
         # Set up logging
-        logging.basicConfig(level=logging.INFO)
+        Config.setup_logging()
         
         # Import necessary modules
         from log_analyzer import parse_logs


### PR DESCRIPTION
## Summary
- remove module-level logging.basicConfig blocks
- use `Config.setup_logging()` for logging init

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*