### PR TITLE
Remove visualization subdirectory usage

### DIFF
--- a/components/component_visualizer.py
+++ b/components/component_visualizer.py
@@ -216,15 +216,7 @@ def _get_visualization_path_internal(output_dir, test_id, visualization_type, ex
     if test_id and not test_id.startswith("SXM-"):
         test_id = f"SXM-{test_id}"
     
-    # Check for nested directories
-    if "supporting_images" in output_dir:
-        # Already has supporting_images, don't nest further
-        viz_dir = output_dir
-    else:
-        # Add supporting_images subdirectory
-        viz_dir = os.path.join(output_dir, "supporting_images")
-    
-    # Create directory
+    viz_dir = output_dir
     os.makedirs(viz_dir, exist_ok=True)
     
     # Create filename and path
@@ -818,12 +810,12 @@ class ComponentVisualizer:
             
             # Sanitize output directory and use path utilities
             if HAS_PATH_UTILS:
-                output_dir = sanitize_base_directory(output_dir, "supporting_images")
+                output_dir = sanitize_base_directory(output_dir)
                 image_path = get_output_path(
-                    output_dir, 
-                    test_id or "default", 
+                    output_dir,
+                    test_id or "default",
                     get_standardized_filename(test_id or "default", "component_relationships", "png"),
-                    OutputType.VISUALIZATION
+                    OutputType.PRIMARY_REPORT
                 )
             else:
                 image_path = _get_visualization_path_internal(
@@ -983,20 +975,20 @@ class ComponentVisualizer:
             
             # Sanitize output directory and use path utilities
             if HAS_PATH_UTILS:
-                output_dir = sanitize_base_directory(output_dir, "supporting_images")
+                output_dir = sanitize_base_directory(output_dir)
                 # Both visualization filenames for backward compatibility
                 distribution_path = get_output_path(
                     output_dir, 
                     test_id, 
                     get_standardized_filename(test_id, "component_distribution", "png"),
-                    OutputType.VISUALIZATION
+                    OutputType.PRIMARY_REPORT
                 )
                 
                 errors_path = get_output_path(
                     output_dir, 
                     test_id, 
                     get_standardized_filename(test_id, "component_errors", "png"),
-                    OutputType.VISUALIZATION
+                    OutputType.PRIMARY_REPORT
                 )
             else:
                 distribution_path = _get_visualization_path_internal(
@@ -1210,12 +1202,12 @@ class ComponentVisualizer:
             
             # Sanitize output directory and use path utilities
             if HAS_PATH_UTILS:
-                output_dir = sanitize_base_directory(output_dir, "supporting_images")
+                output_dir = sanitize_base_directory(output_dir)
                 image_path = get_output_path(
-                    output_dir, 
-                    test_id, 
+                    output_dir,
+                    test_id,
                     get_standardized_filename(test_id, "error_propagation", "png"),
-                    OutputType.VISUALIZATION
+                    OutputType.PRIMARY_REPORT
                 )
             else:
                 image_path = _get_visualization_path_internal(

--- a/controller.py
+++ b/controller.py
@@ -71,7 +71,7 @@ def generate_visualization_placeholder(output_dir, test_id, message):
             output_dir,
             test_id,
             get_standardized_filename(test_id, "visualization_placeholder", "png"),
-            OutputType.VISUALIZATION
+            OutputType.PRIMARY_REPORT
         )
         
         plt.figure(figsize=(8, 6))

--- a/reports/component_analyzer.py
+++ b/reports/component_analyzer.py
@@ -328,14 +328,14 @@ def get_visualization_path(output_dir, test_id, visualization_type, extension="p
         Standardized path for the visualization
     """
     # Sanitize output directory to prevent nested directories
-    output_dir = sanitize_base_directory(output_dir, "supporting_images")
+    output_dir = sanitize_base_directory(output_dir)
     
     # Use path utilities consistently
     return get_output_path(
         output_dir,
         test_id,
         get_standardized_filename(test_id, visualization_type, extension),
-        OutputType.VISUALIZATION
+        OutputType.PRIMARY_REPORT
     )
 
 def get_path_reference(path, base_dir, reference_type="html"):

--- a/reports/component_report.py
+++ b/reports/component_report.py
@@ -119,7 +119,7 @@ def generate_component_visualization(
             output_dir,
             test_id,
             get_standardized_filename(test_id, "component_errors", "png"),
-            OutputType.VISUALIZATION
+            OutputType.PRIMARY_REPORT
         )
         
         # Verify we have valid data for visualization
@@ -207,7 +207,7 @@ def generate_component_visualization(
                 output_dir,
                 test_id,
                 get_standardized_filename(test_id, "component_distribution", "png"),
-                OutputType.VISUALIZATION
+                OutputType.PRIMARY_REPORT
             )
             
             # Copy the file instead of regenerating the figure

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -131,7 +131,6 @@ except ImportError:
     class OutputType:
         PRIMARY_REPORT = "primary"
         JSON_DATA = "json"
-        VISUALIZATION = "image"
         DEBUGGING = "debug"
     
     def get_output_path(base_dir, test_id, filename, output_type=OutputType.PRIMARY_REPORT, create_dirs=True):
@@ -139,8 +138,6 @@ except ImportError:
         
         if output_type == OutputType.JSON_DATA:
             return os.path.join(dirs["json"], filename)
-        elif output_type == OutputType.VISUALIZATION:
-            return os.path.join(dirs["images"], filename)
         elif output_type == OutputType.DEBUGGING:
             return os.path.join(dirs["debug"], filename)
         else:

--- a/tests/report_tests.py
+++ b/tests/report_tests.py
@@ -1000,13 +1000,13 @@ class TestReportsIntegration(unittest.TestCase):
                 TEST_CONFIG["OUTPUT_DIR"],
                 self.test_id,
                 "",
-                OutputType.VISUALIZATION
+                OutputType.PRIMARY_REPORT
             ).rstrip(os.sep)
         else:
             # Set up output directory with standard structure
             self.output_dir = os.path.join(TEST_CONFIG["OUTPUT_DIR"], self.test_id)
             self.json_dir = os.path.join(self.output_dir, "json")
-            self.images_dir = os.path.join(self.output_dir, "supporting_images")
+            self.images_dir = self.output_dir
         
         # Create directories
         os.makedirs(self.output_dir, exist_ok=True)

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -98,7 +98,6 @@ try:
                     """Minimal OutputType enumeration."""
                     PRIMARY_REPORT = "primary"
                     JSON_DATA = "json"
-                    VISUALIZATION = "image"
                     DEBUGGING = "debug"
                 
                 def normalize_test_id(test_id):
@@ -199,11 +198,7 @@ try:
                         return path
                     
                     # Determine subdirectory based on output type
-                    if output_type == OutputType.VISUALIZATION:
-                        # CRITICAL FIX: Create supporting_images subdirectory directly under test_dir, not nested
-                        # This avoids the double supporting_images path issue
-                        subdir = os.path.join(test_dir, "supporting_images")
-                    elif output_type == OutputType.DEBUGGING:
+                    if output_type == OutputType.DEBUGGING:
                         subdir = os.path.join(test_dir, "debug")
                     else:
                         subdir = test_dir

--- a/tests/structure_tests.py
+++ b/tests/structure_tests.py
@@ -184,12 +184,12 @@ class DirectoryStructureTest(unittest.TestCase):
         # Image (supporting_images subdirectory)
         image_filename = get_standardized_filename(self.test_id, "test", "png")
         image_path = get_output_path(
-            self.temp_dir, 
-            self.test_id, 
-            image_filename, 
-            OutputType.VISUALIZATION
+            self.temp_dir,
+            self.test_id,
+            image_filename,
+            OutputType.PRIMARY_REPORT
         )
-        expected_image_path = os.path.join(self.temp_dir, "supporting_images", image_filename)
+        expected_image_path = os.path.join(self.temp_dir, image_filename)
         self.assertEqual(image_path, expected_image_path,
                       f"Image path incorrect: {image_path} != {expected_image_path}")
         
@@ -631,10 +631,10 @@ class PathSanitizationTest(unittest.TestCase):
         
         # Problematic case - supporting_images subdirectory
         image_filename = get_standardized_filename(self.test_id, "test", "png")
-        path = get_output_path(self.images_dir, self.test_id, image_filename, OutputType.VISUALIZATION)
-        expected_image_path = os.path.join(self.temp_dir, "supporting_images", image_filename)
+        path = get_output_path(self.images_dir, self.test_id, image_filename, OutputType.PRIMARY_REPORT)
+        expected_image_path = os.path.join(self.temp_dir, image_filename)
         self.assertEqual(path, expected_image_path, "Path sanitization failed for images subdirectory")
-        self.assertNotIn("supporting_images/supporting_images", path.replace("\\", "/"), 
+        self.assertNotIn("supporting_images/supporting_images", path.replace("\\", "/"),
                       "Nested supporting_images directory detected")
     
     def test_cleanup_nested_directories(self):

--- a/tests/utils/path_utils_test.py
+++ b/tests/utils/path_utils_test.py
@@ -58,17 +58,14 @@ class TestPathUtils(unittest.TestCase):
         
         # Check directories are created
         json_dir = os.path.join(self.temp_dir, "json")
-        images_dir = os.path.join(self.temp_dir, "supporting_images")
         debug_dir = os.path.join(self.temp_dir, "debug")
         
         self.assertTrue(os.path.exists(json_dir), "JSON directory was not created")
-        self.assertTrue(os.path.exists(images_dir), "Supporting images directory was not created")
         self.assertTrue(os.path.exists(debug_dir), "Debug directory was not created")
         
         # Check paths in returned dictionary
         self.assertEqual(output_paths["base"], self.temp_dir)
         self.assertEqual(output_paths["json"], json_dir)
-        self.assertEqual(output_paths["images"], images_dir)
         self.assertEqual(output_paths["debug"], debug_dir)
         
         # Test without SXM- prefix
@@ -91,10 +88,6 @@ class TestPathUtils(unittest.TestCase):
         self.assertEqual(json_path, os.path.join(self.temp_dir, "json", filename))
         self.assertTrue(os.path.exists(os.path.dirname(json_path)))
         
-        # Test VISUALIZATION
-        viz_path = get_output_path(self.temp_dir, self.test_id, filename, OutputType.VISUALIZATION)
-        self.assertEqual(viz_path, os.path.join(self.temp_dir, "supporting_images", filename))
-        self.assertTrue(os.path.exists(os.path.dirname(viz_path)))
         
         # Test DEBUGGING
         debug_path = get_output_path(self.temp_dir, self.test_id, filename, OutputType.DEBUGGING)
@@ -160,16 +153,12 @@ def test_path_utils():
                 return False
                 
             json_dir = os.path.join(temp_dir, "json")
-            images_dir = os.path.join(temp_dir, "supporting_images")
             debug_dir = os.path.join(temp_dir, "debug")
             
             if not os.path.exists(json_dir):
                 print("❌ setup_output_directories failed to create json directory")
                 return False
                 
-            if not os.path.exists(images_dir):
-                print("❌ setup_output_directories failed to create supporting_images directory")
-                return False
                 
             if not os.path.exists(debug_dir):
                 print("❌ setup_output_directories failed to create debug directory")
@@ -198,11 +187,6 @@ def test_path_utils():
                 print(f"❌ get_output_path returned incorrect path for JSON_DATA: {json_path}")
                 return False
                 
-            # Test VISUALIZATION
-            viz_path = get_output_path(temp_dir, test_id, filename, OutputType.VISUALIZATION)
-            if viz_path != os.path.join(temp_dir, "supporting_images", filename):
-                print(f"❌ get_output_path returned incorrect path for VISUALIZATION: {viz_path}")
-                return False
                 
             # Test DEBUGGING
             debug_path = get_output_path(temp_dir, test_id, filename, OutputType.DEBUGGING)
@@ -241,7 +225,7 @@ if __name__ == "__main__":
     success = test_path_utils()
     if success:
         print("✅ All path_utils tests passed!")
-        sys.exit(0)
     else:
         print("❌ path_utils tests failed!")
         sys.exit(1)
+

--- a/utils/visualization_utils.py
+++ b/utils/visualization_utils.py
@@ -247,29 +247,21 @@ def get_visualization_path(output_dir: str, test_id: str,
     """
     if HAS_PATH_UTILS:
         # Sanitize output directory to prevent nested directories
-        output_dir = sanitize_base_directory(output_dir, "supporting_images")
-        
+        output_dir = sanitize_base_directory(output_dir)
+
         # Use path utilities consistently
         return get_output_path(
             output_dir,
             test_id,
             get_standardized_filename(test_id, visualization_type, extension),
-            OutputType.VISUALIZATION
+            OutputType.PRIMARY_REPORT
         )
     else:
         # Basic sanitization
         if test_id and not test_id.startswith("SXM-"):
             test_id = f"SXM-{test_id}"
         
-        # Check for nested directories
-        if "supporting_images" in output_dir:
-            # Already has supporting_images, don't nest further
-            viz_dir = output_dir
-        else:
-            # Add supporting_images subdirectory
-            viz_dir = os.path.join(output_dir, "supporting_images")
-        
-        # Create directory
+        viz_dir = output_dir
         os.makedirs(viz_dir, exist_ok=True)
         
         # Create filename and path


### PR DESCRIPTION
## Summary
- remove `VISUALIZATION` enum value and references
- stop creating `supporting_images` output folder
- update helper utilities and modules accordingly
- adjust tests for new output layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*