### PR TITLE
Cleanup step report expectations

### DIFF
--- a/fix.py
+++ b/fix.py
@@ -168,13 +168,6 @@ def check_directories_and_files(test_id: str):
         os.makedirs(supporting_images_dir, exist_ok=True)
         logging.info(f"Created supporting_images directory: {supporting_images_dir}")
     
-    # Check for HTML report
-    html_report_path = os.path.join(output_dir, f"{test_id}_step_report.html")
-    if os.path.exists(html_report_path):
-        logging.info(f"HTML report exists: {html_report_path}")
-    else:
-        logging.warning(f"HTML report does not exist: {html_report_path}")
-    
     return True
 
 def check_visualization_module():
@@ -190,12 +183,6 @@ def check_step_aware_analyzer():
     try:
         import step_aware_analyzer
         logging.info("Successfully imported step_aware_analyzer module")
-        available_attrs = dir(step_aware_analyzer)
-        deprecated = [name for name in ("generate_step_report", "run_step_aware_analysis") if name in available_attrs]
-        if deprecated:
-            logging.warning(f"Deprecated functions present: {deprecated}")
-        
-        
         return True
     except Exception as e:
         logging.error(f"Error checking step-aware analyzer: {str(e)}")
@@ -333,16 +320,11 @@ def create_fixed_timeline(test_id: str, step_dict: Dict[int, Dict], step_to_logs
             test_id=test_id
         )
         
-        if timeline_path and os.path.exists(timeline_path):
-            logging.info(f"Timeline visualization generated successfully: {timeline_path}")
-            logging.info(f"File size: {os.path.getsize(timeline_path)} bytes")
+        if timeline_path:
+            logging.info(f"Timeline visualization generated at: {timeline_path}")
             return timeline_path
-        else:
-            if timeline_path:
-                logging.error(f"Timeline path returned but file does not exist: {timeline_path}")
-            else:
-                logging.error("Timeline generation function returned None or empty path")
-            return None
+        logging.error("Timeline generation function returned None or empty path")
+        return None
     except Exception as e:
         logging.error(f"Error creating timeline visualization: {str(e)}")
         traceback.print_exc()
@@ -523,10 +505,6 @@ def run_diagnostic():
     # Print final output locations
     if timeline_path:
         logging.info(f"\nTimeline visualization: {timeline_path}")
-    
-    html_report_path = os.path.join(OUTPUT_DIR, TEST_ID, f"{TEST_ID}_step_report.html")
-    if os.path.exists(html_report_path):
-        logging.info(f"HTML report: {html_report_path}")
     
     logging.info("\nFix script completed. Check logs for details.")
 

--- a/utils/path_validator.py
+++ b/utils/path_validator.py
@@ -54,10 +54,8 @@ def validate_file_structure(base_dir: str, test_id: str) -> Dict[str, List[str]]
     # Look for expected files
     expected_files = [
         (os.path.join(base_dir, f"{test_id}_bug_report.docx"), "Primary report"),
-        (os.path.join(base_dir, f"{test_id}_component_report.html"), "Primary report"),
         (os.path.join(base_dir, f"{test_id}_log_analysis.xlsx"), "Primary report"),
         (os.path.join(json_dir, f"{test_id}_log_analysis.json"), "JSON data"),
-        (os.path.join(images_dir, f"{test_id}_cluster_timeline.png"), "Visualization"),
         (os.path.join(images_dir, f"{test_id}_component_errors.png"), "Component Visualization")
     ]
     
@@ -155,35 +153,11 @@ def print_validation_results(base_dir: str, test_id: str):
                 if len(issues) > 3:
                     print(f"    - ... and {len(issues) - 3} more")
     
-    # Check HTML references
-    html_file = os.path.join(base_dir, f"{test_id}_component_report.html")
-    
-    # Initialize total_html_issues
-    total_html_issues = 0
-    
-    if os.path.exists(html_file):
-        html_issues = check_html_references(html_file)
-        
-        print("\nHTML Reference Issues:")
-        total_html_issues = sum(len(issues) for issues in html_issues.values())
-        if total_html_issues == 0:
-            print("  ✅ No HTML reference issues found")
-        else:
-            for issue_type, issues in html_issues.items():
-                if issues:
-                    print(f"  ❌ {issue_type}: {len(issues)} issues")
-                    for issue in issues[:3]:
-                        print(f"    - {issue}")
-                    if len(issues) > 3:
-                        print(f"    - ... and {len(issues) - 3} more")
-    else:
-        print(f"\n⚠️ HTML file not found: {html_file}")
-    
     # Print overall result
-    if total_structure_issues == 0 and total_html_issues == 0:
-        print("\n✅ VALIDATION PASSED: All files are in correct locations and properly referenced")
+    if total_structure_issues == 0:
+        print("\n✅ VALIDATION PASSED: All files are in correct locations")
     else:
-        print(f"\n❌ VALIDATION FAILED: Found {total_structure_issues} structure issues and {total_html_issues} HTML issues")
+        print(f"\n❌ VALIDATION FAILED: Found {total_structure_issues} structure issues")
 
 def fix_directory_structure(base_dir: str, test_id: str) -> Dict[str, List[str]]:
     """


### PR DESCRIPTION
## Summary
- remove `_step_report.html` checks and timeline image validation in `fix.py`
- drop deprecated function checks in `fix.py`
- simplify `path_validator` to avoid component report expectations
- clean up controller diagnostics and remove unused component report import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*