### PR TITLE
Clean docs of legacy report references

### DIFF
--- a/docs/Orbit Deep Dive.md
+++ b/docs/Orbit Deep Dive.md
@@ -870,7 +870,7 @@ class OutputType(Enum):
     """Enumeration of output file types with their destinations"""
     PRIMARY_REPORT = "primary"  # Goes in root directory (Excel, DOCX, HTML)
     JSON_DATA = "json"          # Goes in json/ subdirectory
-    VISUALIZATION = "image"     # Goes in supporting_images/ subdirectory
+    VISUALIZATION = "image"
     DEBUGGING = "debug"         # Goes in debug/ subdirectory (optional)
 
 def get_output_path(
@@ -905,7 +905,7 @@ def get_output_path(
     if output_type == OutputType.JSON_DATA:
         subdir = os.path.join(test_dir, "json")
     elif output_type == OutputType.VISUALIZATION:
-        subdir = os.path.join(test_dir, "supporting_images")
+        subdir = os.path.join(test_dir, "images")
     elif output_type == OutputType.DEBUGGING:
         subdir = os.path.join(test_dir, "debug")
     else:  # PRIMARY_REPORT
@@ -922,7 +922,7 @@ def get_output_path(
 This system ensures that:
 - Primary reports are stored in the root test directory
 - JSON data files are stored in the `json/` subdirectory
-- Visualizations are stored in the `supporting_images/` subdirectory
+- Visualization assets are stored in a dedicated `images/` subdirectory
 - Debug information is stored in the `debug/` subdirectory
 
 ## GPT-Powered Root Cause Analysis

--- a/docs/Orbit Technical Guide.md
+++ b/docs/Orbit Technical Guide.md
@@ -359,7 +359,7 @@ class OutputType(Enum):
     """Enumeration of output file types with their destinations"""
     PRIMARY_REPORT = "primary"  # Goes in root directory (Excel, DOCX, HTML)
     JSON_DATA = "json"          # Goes in json/ subdirectory
-    VISUALIZATION = "image"     # Goes in supporting_images/ subdirectory
+    VISUALIZATION = "image"
     DEBUGGING = "debug"         # Goes in debug/ subdirectory (optional)
 
 def normalize_test_id(test_id: str) -> str:
@@ -624,21 +624,13 @@ output/
 |   |-- SXM-123456_log_analysis.xlsx   # Main Excel report
 |   |-- SXM-123456_bug_report.docx     # Bug report document
 |   |-- SXM-123456_log_analysis.md     # Markdown report
-|   |-- SXM-123456_component_report.html # Component analysis report
-|   |
 |   +-- json/                          # JSON data subdirectory
 |   |   |-- SXM-123456_log_analysis.json # Main analysis data
 |   |   |-- SXM-123456_component_analysis.json # Component analysis data
 |   |   |-- SXM-123456_error_graph.json # Error relationship graph
 |   |   +-- SXM-123456_component_preservation.json # Component preservation data
 |   |
-|   +-- supporting_images/             # Visualizations subdirectory
-|   |   |-- SXM-123456_timeline.png    # Standard timeline visualization
-|   |   |-- SXM-123456_cluster_timeline.png # Cluster timeline visualization
-|   |   |-- SXM-123456_component_relationships.png # Component relationship diagram
-|   |   |-- SXM-123456_error_propagation.png # Error propagation diagram
-|   |   +-- SXM-123456_component_distribution.png # Component error distribution
-|   |
+|
 |   +-- debug/                         # Debug information
 |       |-- SXM-123456_timeline_debug.txt # Timeline generation debug log
 |       +-- SXM-123456_component_debug.txt # Component analysis debug log
@@ -745,7 +737,7 @@ Config.setup_logging()
 Config.validate()
 
 # Run analysis
-result, step_report = run_pipeline(
+result, _ = run_pipeline(
     test_id="SXM-1234567",
     gpt_model="gpt-3.5-turbo",
     enable_ocr=True,
@@ -754,8 +746,6 @@ result, step_report = run_pipeline(
 
 # Access results
 print(f"Analysis completed: {result}")
-if step_report:
-    print(f"Step report generated at: {step_report}")
 ```
 
 ### Batch Processing
@@ -874,7 +864,7 @@ print_validation_results("output/SXM-1234567", "SXM-1234567")
 
 # Check HTML references
 from utils.path_validator import check_html_references
-issues = check_html_references("output/SXM-1234567/SXM-1234567_component_report.html")
+issues = check_html_references("output/SXM-1234567/log_analysis.html")
 print(issues)
 ```
 
@@ -962,8 +952,7 @@ def process_large_logs(log_files, chunk_size=1000):
    - Use `get_standardized_filename()` for consistent naming
 
 5. **HTML References**
-   - Always use `supporting_images/` prefix in HTML
-   - Use relative paths for better portability
+   - Use relative paths for portability
    - Validate HTML references with `check_html_references()`
 
 ## Extending Orbit

--- a/docs/Orbit User Guide.md
+++ b/docs/Orbit User Guide.md
@@ -137,17 +137,10 @@ Orbit/
 │       ├── SXM-1234567_log_analysis.xlsx        # Main Excel report
 │       ├── SXM-1234567_bug_report.docx          # Bug report document
 │       ├── SXM-1234567_log_analysis.md          # Markdown report
-│       ├── SXM-1234567_component_report.html    # Component analysis report
-│       │
 │       ├── json/                                # Detailed data files
 │       │   ├── SXM-1234567_log_analysis.json
 │       │   └── SXM-1234567_component_analysis.json
 │       │
-│       └── supporting_images/                   # Visualizations
-│           ├── SXM-1234567_timeline.png
-│           ├── SXM-1234567_cluster_timeline.png
-│           ├── SXM-1234567_component_relationships.png
-│           └── SXM-1234567_component_distribution.png
 ```
 
 ## Understanding the Output
@@ -167,14 +160,6 @@ The most comprehensive report with multiple tabs:
 | Cluster Summary | Overview of each error cluster |
 | Images extraction | Text extracted from screenshots |
 
-### Component Report (SXM-1234567_component_report.html)
-
-An interactive report showing:
-* Which components are experiencing issues
-* How components relate to each other
-* Error distribution across components
-* Possible error propagation paths
-
 ### Markdown Summary (SXM-1234567_log_analysis.md)
 
 A simple text summary that can be easily copied into:
@@ -191,14 +176,6 @@ A formatted document ready for Jira submission with:
 * Log snippets
 * Expected vs. actual behavior
 
-### Visualizations (in supporting_images/)
-
-| Visualization | Shows |
-|---------------|-------|
-| Timeline | When errors occurred during test execution |
-| Cluster Timeline | Error clusters over time with color coding |
-| Component Relationships | How different components interact |
-| Component Distribution | Which components have the most errors |
 
 ## Common Issues and Solutions
 
@@ -216,7 +193,6 @@ A formatted document ready for Jira submission with:
 
 * **Include diverse logs**: Logs from different components provide better analysis of relationships and root causes
 * **Organize by test ID**: Use the standard SXM-#### format for your test ID folders
-* **Review visualizations**: The timeline and component visualizations often make patterns obvious at a glance
 * **Use batch processing**: When analyzing multiple test failures, use batch processing to save time
 
 ## Need More Help?

--- a/docs/Orbit_Getting_Started.md
+++ b/docs/Orbit_Getting_Started.md
@@ -161,17 +161,10 @@ output/
     ├── SXM-2302295_log_analysis.xlsx       # Main Excel report
     ├── SXM-2302295_bug_report.docx         # Bug report document
     ├── SXM-2302295_log_analysis.md         # Markdown report
-    ├── SXM-2302295_component_report.html   # Component analysis report
-    │
     ├── json/                               # Detailed data files
     │   ├── SXM-2302295_log_analysis.json
     │   └── SXM-2302295_component_analysis.json
     │
-    └── supporting_images/                  # Visualizations
-        ├── SXM-2302295_timeline.png
-        ├── SXM-2302295_cluster_timeline.png
-        ├── SXM-2302295_component_relationships.png
-        └── SXM-2302295_component_distribution.png
 ```
 
 ---
@@ -188,20 +181,6 @@ The most comprehensive report with multiple tabs:
 - **Cluster Summary**: Overview of each error cluster
 - **Images extraction**: Text extracted from screenshots
 
-### Component Report (SXM-2302295_component_report.html)
-
-An interactive report showing:
-- Which components are experiencing issues
-- How components relate to each other
-- Error distribution across components
-- Possible error propagation paths
-
-### Visualizations (in supporting_images/)
-
-- **Timeline**: When errors occurred during test execution
-- **Cluster Timeline**: Error clusters over time with color coding
-- **Component Relationships**: How different components interact
-- **Component Distribution**: Which components have the most errors
 
 ---
 
@@ -231,7 +210,6 @@ See:
 
 - **Include diverse logs**: Logs from different components provide better analysis of relationships and root causes
 - **Organize by test ID**: Use the standard SXM-#### format for your test ID folders
-- **Review visualizations**: The timeline and component visualizations often make patterns obvious at a glance
 - **Use batch processing**: When analyzing multiple test failures, use batch processing to save time
 
 ---

--- a/docs/development-workflow-guide.md
+++ b/docs/development-workflow-guide.md
@@ -256,14 +256,8 @@ Based on the current codebase patterns:
    ```
 
 2. **HTML Path References**
-   - Always use `supporting_images/` prefix for image references in HTML
    - Validate HTML references using `utils.path_validator`
    - Use relative paths for better portability
-
-   ```html
-   <!-- Correct HTML image reference -->
-   <img src="supporting_images/SXM-123456_component_distribution.png" alt="Component Distribution">
-   ```
 
 ### Error Handling Practices
 
@@ -369,8 +363,6 @@ python -c "import json; print(json.load(open('output/SXM-123456/json/SXM-123456_
 # Diagnose output structure
 python -c "from controller import diagnose_output_structure; diagnose_output_structure('SXM-123456')"
 
-# Verify visualization images
-python -c "from PIL import Image; Image.open('output/SXM-123456/supporting_images/SXM-123456_component_errors.png').verify()"
 ```
 
 #### Building Executable
@@ -967,11 +959,9 @@ logs/
 2. **Directory Structure Compliance**
    - Keep main reports in root directory
    - JSON data files in `json/` subdirectory
-   - Visualizations in `supporting_images/` subdirectory
    - Debug information in `debug/` subdirectory
 
 3. **HTML References**
-   - Always use `supporting_images/` prefix in HTML
    - Use relative paths for better portability
    - Validate HTML references with `check_html_references()`
 

--- a/docs/environment-config-docs.md
+++ b/docs/environment-config-docs.md
@@ -243,7 +243,7 @@ class OutputType(Enum):
     """Enumeration of output file types with their destinations"""
     PRIMARY_REPORT = "primary"  # Goes in root directory (Excel, DOCX, HTML)
     JSON_DATA = "json"          # Goes in json/ subdirectory
-    VISUALIZATION = "image"     # Goes in supporting_images/ subdirectory
+    VISUALIZATION = "image"
     DEBUGGING = "debug"         # Goes in debug/ subdirectory (optional)
 
 def normalize_test_id(test_id: str) -> str:
@@ -282,21 +282,12 @@ output/
 |   |-- SXM-123456_log_analysis.xlsx   # Main Excel report
 |   |-- SXM-123456_bug_report.docx     # Bug report document
 |   |-- SXM-123456_log_analysis.md     # Markdown report
-|   |-- SXM-123456_component_report.html # Component analysis report
-|   |
 |   +-- json/                          # JSON data subdirectory
 |   |   |-- SXM-123456_log_analysis.json # Main analysis data
 |   |   |-- SXM-123456_component_analysis.json # Component analysis data
 |   |   +-- SXM-123456_component_preservation.json # Component preservation data
 |   |
-|   +-- supporting_images/             # Visualizations subdirectory
-|   |   |-- SXM-123456_timeline.png    # Standard timeline visualization
-|   |   |-- SXM-123456_cluster_timeline.png # Cluster timeline visualization
-|   |   |-- SXM-123456_component_errors.png # Component error distribution visualization
-|   |   |-- SXM-123456_component_distribution.png # Alias for component_errors.png
-|   |   |-- SXM-123456_component_relationships.png # Component relationship diagram
-|   |   |-- SXM-123456_error_propagation.png # Error propagation visualization
-|   |
+|
 |   +-- debug/                         # Debug information
 |       |-- SXM-123456_timeline_debug.txt # Timeline generation debug log
 ```
@@ -882,17 +873,14 @@ class ReportManager:
         
         # Create output directory structures
         self.base_dir = config.output_dir
-        self.json_dir = os.path.join(config.output_dir, "json") 
-        self.images_dir = os.path.join(config.output_dir, "supporting_images")
+        self.json_dir = os.path.join(config.output_dir, "json")
         
         # Create directories
         os.makedirs(self.base_dir, exist_ok=True)
         os.makedirs(self.json_dir, exist_ok=True)
-        os.makedirs(self.images_dir, exist_ok=True)
         
         # Initialize report generators
         self.json_generator = JsonReportGenerator(self._create_config_for_dir(self.json_dir)) if config.enable_json else None
-        self.visualization_generator = VisualizationGenerator(self._create_config_for_dir(self.images_dir)) if config.enable_component_report else None
         self.markdown_generator = MarkdownReportGenerator(config) if config.enable_markdown else None
         self.excel_generator = ExcelReportGenerator(config) if config.enable_excel else None
         self.docx_generator = DocxReportGenerator(config) if config.enable_docx else None

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -107,8 +107,6 @@ python batch_processor.py --all --parallel
 All reports are generated in the `output\SXM-xxxxxxx` folder:
 - `log_analysis.html` - Main HTML report
 - `SXM-xxxxxxx_bug_report.docx` - Ready-to-submit bug report
-- `SXM-xxxxxxx_component_report.html` - Component relationship analysis
-- Various visualization files (PNG)
 
 HTML reports are rendered using **Jinja2** templates located in `reports/templates`.
 
@@ -188,7 +186,6 @@ Configure by editing `config.py` or setting environment variables:
 * `OPENAI_API_KEY`: API key for GPT analysis (set as environment variable)
 * `DEFAULT_MODEL`: GPT model to use (default: `gpt-3.5-turbo`)
 * `ENABLE_OCR`: Whether to extract text from images (default: `True`)
-* `ENABLE_STEP_REPORT`: Generate the step-aware HTML report (default: `True`)
 
 For secure API key storage, you can use the Windows Credential Manager:
 


### PR DESCRIPTION
## Summary
- remove references to *_component_report.html* and *_step_report.html*
- drop mentions of `supporting_images` directories across docs
- update example directory trees and config snippets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*