### PR TITLE
Fix docx generator param and directory structure issue

### DIFF
--- a/utils/path_validator.py
+++ b/utils/path_validator.py
@@ -175,7 +175,8 @@ def fix_directory_structure(base_dir: str, test_id: str) -> Dict[str, List[str]]
         "images_dir_json": [],
         "nested_directories": [],
         "misplaced_visualizations": [],
-        "fixed_files": []
+        "fixed_files": [],
+        "expected_but_missing": []
     }
     
     # First, clean up nested directories


### PR DESCRIPTION
## Summary
- prevent KeyError in `fix_directory_structure` by tracking missing files
- extend `generate_bug_document` signature and add optional report link
- pass through component report path when generating DOCX reports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*