### PR TITLE
Disable generation of component relationship diagram

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,7 +63,8 @@ class Config:
     # Defaults are set to provide the most useful visualizations while maintaining backwards compatibility
     ENABLE_CLUSTER_TIMELINE = os.getenv("ENABLE_CLUSTER_TIMELINE", "False").lower() in ("true", "1", "yes")
     ENABLE_COMPONENT_DISTRIBUTION = os.getenv("ENABLE_COMPONENT_DISTRIBUTION", "True").lower() in ("true", "1", "yes")
-    ENABLE_COMPONENT_RELATIONSHIPS = os.getenv("ENABLE_COMPONENT_RELATIONSHIPS", "True").lower() in ("true", "1", "yes")
+    # Disable component relationship diagrams by default
+    ENABLE_COMPONENT_RELATIONSHIPS = os.getenv("ENABLE_COMPONENT_RELATIONSHIPS", "False").lower() in ("true", "1", "yes")
     ENABLE_ERROR_PROPAGATION = os.getenv("ENABLE_ERROR_PROPAGATION", "False").lower() in ("true", "1", "yes")
     
     # Step report and timeline visualizations

--- a/docs/development-workflow-guide.md
+++ b/docs/development-workflow-guide.md
@@ -772,7 +772,7 @@ Feature flags in `config.py` can be used to control behavior:
 | `ENABLE_ERROR_PROPAGATION` | Enable error propagation visualization | `False` |
 | `ENABLE_STEP_REPORT_IMAGES` | Enable step report visualizations | `False` |
 | `ENABLE_COMPONENT_REPORT_IMAGES` | Enable component report visualizations | `True` |
-| `ENABLE_COMPONENT_RELATIONSHIPS` | Enable component relationship diagrams | `True` |
+| `ENABLE_COMPONENT_RELATIONSHIPS` | Enable component relationship diagrams | `False` |
 
 ### Debugging Tools
 

--- a/docs/environment-config-docs.md
+++ b/docs/environment-config-docs.md
@@ -56,7 +56,7 @@ class Config:
     # Visualization enablement flags
     ENABLE_CLUSTER_TIMELINE = False
     ENABLE_COMPONENT_DISTRIBUTION = True
-    ENABLE_COMPONENT_RELATIONSHIPS = True
+    ENABLE_COMPONENT_RELATIONSHIPS = False
     ENABLE_ERROR_PROPAGATION = False
     ENABLE_STEP_REPORT_IMAGES = False
     ENABLE_COMPONENT_REPORT_IMAGES = True
@@ -176,7 +176,7 @@ The system implements several feature flags in the `Config` class to control vis
 # Visualization enablement flags
 ENABLE_CLUSTER_TIMELINE = False         # Enable cluster timeline visualization
 ENABLE_COMPONENT_DISTRIBUTION = True    # Enable component distribution charts
-ENABLE_COMPONENT_RELATIONSHIPS = True   # Enable component relationship diagrams
+ENABLE_COMPONENT_RELATIONSHIPS = False  # Enable component relationship diagrams
 ENABLE_ERROR_PROPAGATION = False        # Enable error propagation visualization
 ENABLE_STEP_REPORT_IMAGES = False       # Enable step report images
 ENABLE_COMPONENT_REPORT_IMAGES = True   # Enable all component report visualizations

--- a/tests/component_tests.py
+++ b/tests/component_tests.py
@@ -910,13 +910,9 @@ class TestComponentVisualizer(unittest.TestCase):
         test_id = "TEST-VIZ-123"
         dirs = setup_test_output_directories(test_id)
         diagram_path = self.visualizer.generate_component_relationship_diagram(dirs["images"])
-        
-        # Verify the diagram was created
-        self.assertIsNotNone(diagram_path)
-        
-        # Validate the visualization
-        is_valid, issues = validate_visualization(diagram_path)
-        self.assertTrue(is_valid, f"Visualization validation failed: {', '.join(issues)}")
+
+        # Diagram generation is disabled by default; expect None
+        self.assertIsNone(diagram_path)
     
     def test_generate_error_propagation_diagram(self):
         """


### PR DESCRIPTION
## Summary
- turn off component relationship diagram generation in `Config`
- document the updated default for `ENABLE_COMPONENT_RELATIONSHIPS`
- adjust tests to expect no diagram when feature is disabled

## Testing
- `python tests/run_all_tests.py --skip-slow` *(fails: ModuleNotFoundError: No module named 'networkx' and unexpected indent in report_tests.py)*
- `python -m unittest tests.component_tests.TestComponentVisualizer.test_generate_component_relationship_diagram` *(fails: ModuleNotFoundError: No module named 'networkx')*